### PR TITLE
feat(ci): add NuGet cache step to speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
 
       - run: dotnet restore
       - run: dotnet build --no-restore


### PR DESCRIPTION
Changes:
- Added a step to cache NuGet packages using `actions/cache@v3`
- This improves workflow performance by avoiding redundant downloads
- Cache key is based on `.csproj` hash, so it's automatically updated on changes